### PR TITLE
Remove duplicate viewport meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
     <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
 <link rel="stylesheet" href="styles.css">
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&display=swap" rel="stylesheet">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 
 


### PR DESCRIPTION
## Summary
- remove redundant viewport meta tag from index page head

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e933132048333a6d988f0a50e5538