### PR TITLE
refactor: externalize inline styles and scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1089 +1,901 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Official portfolio of Tadros Karam, computer engineering student.">
-<meta name="author" content="Tadros Karam">
-<meta name="robots" content="index, follow">
-<meta name="keywords" content="Tadros Karam, Portfolio, Java, Web Development, Engineering, Ain Shams">
-<meta name="google-site-verification" content="HqbjlVBZB_aCcAV1wjli0gyI1l8JxLXmgumC44iYx3g" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Official portfolio of Tadros Karam, computer engineering student."
+    />
+    <meta name="author" content="Tadros Karam" />
+    <meta name="robots" content="index, follow" />
+    <meta
+      name="keywords"
+      content="Tadros Karam, Portfolio, Java, Web Development, Engineering, Ain Shams"
+    />
+    <meta
+      name="google-site-verification"
+      content="HqbjlVBZB_aCcAV1wjli0gyI1l8JxLXmgumC44iYx3g"
+    />
 
     <title>Tadros Karam - Portfolio</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="icon" href="icon.png" type="image/x-icon">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+    <link rel="icon" href="icon.png" type="image/x-icon" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
 
     <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
-<link rel="stylesheet" href="styles.css">
-<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&amp;display=swap"
+      rel="stylesheet"
+    />
+  </head>
 
+  <body class="text-gray-500" id="home">
+    <!-- pointer effect -->
+    <!-- <div class="circle"></div> -->
 
+    <header class="h-screen flex inline-style-1">
+      <!-- image -->
+      <div class="inline-style-2">
+        <div class="glow-rotate-wrapper">
+          <div class="glow-rotate"></div>
+          <div class="inline-style-3"></div>
+        </div>
+      </div>
 
-   
-</head>
+      <button id="theme-toggle" class="inline-style-4">
+        <i class="fas fa-moon"></i>
+        <span>Dark Mode</span>
+      </button>
 
-<body class="text-gray-500" id="home" >
+      <!-- content -->
 
-        <!-- pointer effect -->
-     <!-- <div class="circle"></div> -->
+      <div class="inline-style-5">
+        <div class="inline-style-6">
+          <i>
+            <h1
+              class="font-semibold slide-in-left inline-style-7"
+              id="main-title-font"
+            >
+              Tadros Karam
+            </h1>
+          </i>
 
-    <header class="h-screen flex" style="width: 100%; border-bottom: 4px solid #ffc005; ">
+          <h3 id="hacking-title" class="inline-style-8"></h3>
 
-     <!-- image -->
-  <div style="margin-right: -200px; width: 50%; display: flex; align-items: center; justify-content: center;">
-    <div class="glow-rotate-wrapper">
-      <div class="glow-rotate"></div>
-      <div
-     style="
-       width: 550px;
-       height: 550px;
-       background-image: url('Screenshot_7-removebg-preview\ \(1\).png');
-       background-size: cover;
-       background-repeat: no-repeat;
-       background-position:initial;
-       border-bottom-right-radius: 20px;
-       border-radius: 50%;
-       z-index: 2;
-       position: relative;
-     "
-      ></div>
-    </div>
-    <style>
-      .glow-rotate-wrapper {
-     position: relative;
-     width: 580px;
-     height: 580px;
-     display: flex;
-     align-items: center;
-     justify-content: center;
-      
-  border-radius: 50%;
-      }
- .glow-rotate {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  background: conic-gradient(
-    #fffacd 0deg,      /* LemonChiffon */
-    #ffc107 60deg,     /* Amber */
-    #f59e0b 120deg,    /* Golden Orange */
-    #facc15 180deg,    /* Sunflower */
-    #ffeb3b 240deg,    /* Bright Yellow */
-    #ffd700 300deg,    /* Gold */
-    #fffacd 360deg     /* Back to LemonChiffon */
-  );
-  filter: blur(40px) brightness(1.1);
-  z-index: 999;
-  animation: rotateGlow 5s linear infinite;
-  opacity: 0.25;
-}
-
- 
-  
-      @keyframes rotateGlow {
-     100% {
-       transform: rotate(360deg);
-     }
-      }
-    </style>
-  </div>
- 
-<button id="theme-toggle"
-  style="
-    position: fixed;
-  top: 15px;
-  right: 20px;
-    background-color: #161515;
-    color: white;
-    padding: 10px 16px;
-    border: none;
-    border-radius: 8px;
-    font-weight: bold;
-    cursor: pointer;
-    z-index: 9999;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-    transition: background-color 0.3s ease;">
-  <i class="fas fa-moon"></i>
-  <span>Dark Mode</span>
-</button>
-
-
-
-    <style>
-      /* Hamburger visible only on small screens */
-      @media (max-width: 1024px) {
-        #nav-hamburger {
-          display: block !important;
-        }
-        #main-nav-list {
-          display: none;
-          position: absolute;
-          top: 70px;
-          left: 0;
-          width: 100vw;
-          flex-direction: column;
-          background: rgba(35, 37, 37, 0.97);
-          gap: 0;
-          padding: 20px 0 10px 0;
-          z-index: 1100;
-        }
-        #main-nav-list.open {
-          display: flex !important;
-        }
-        #main-nav-list li {
-          margin: 0 0 18px 0;
-          text-align: center;
-        }
-        #main-nav-list li:last-child {
-          margin-bottom: 0;
-        }
-      }
-      @media (min-width: 1025px) {
-        #main-nav-list {
-          display: flex !important;
-          position: static;
-          flex-direction: row;
-          background: none;
-          gap: 30px;
-        }
-        #nav-hamburger {
-          display: none !important;
-        }
-      }
-    </style>
-    <script>
-      // Hamburger menu toggle for small screens, always show nav on large screens
-      document.addEventListener('DOMContentLoaded', function() {
-        const btn = document.getElementById('nav-hamburger');
-        const navList = document.getElementById('main-nav-list');
-        function updateNavDisplay() {
-          if (window.innerWidth > 1024) {
-            navList.classList.add('open');
-            navList.style.display = 'flex';
-          } else {
-            navList.classList.remove('open');
-            navList.style.display = '';
-          }
-        }
-        updateNavDisplay();
-        window.addEventListener('resize', updateNavDisplay);
-
-        if (!btn || !navList) return;
-        btn.addEventListener('click', function() {
-          if (window.innerWidth <= 1024) {
-            navList.classList.toggle('open');
-            if (navList.classList.contains('open')) {
-              navList.style.display = 'flex';
-            } else {
-              navList.style.display = '';
-            }
-          }
-        });
-        // Close menu when clicking a link (on small screens)
-        navList.querySelectorAll('a').forEach(link => {
-          link.addEventListener('click', function() {
-            if (window.innerWidth <= 1024) {
-              navList.classList.remove('open');
-              navList.style.display = '';
-            }
-          });
-        });
-      });
-    </script>
-
-  </nav>
-
-</div>
-
-
-
-</div>
-
-    <!-- content -->
-
-    <div style="width: 50%;">
-
-   
-
-
-
-
-    <div style="display: flex; align-items: center; justify-content: center; flex-direction: column; height: 100%;">
-      <i>
-        <h1
-          style="font-size: 100px; background-color: white; -webkit-background-clip: text; -webkit-text-fill-color: transparent;"
-          class="font-semibold slide-in-left"
-          id="main-title-font"
-        >
-          Tadros Karam
-        </h1>
-      </i>
-      <style>
-        .slide-in-left {
-          opacity: 0;
-          transform: translateX(-100%);
-          animation: slideInLeft 1s cubic-bezier(.4,1.7,.6,1) forwards;
-        }
-        @keyframes slideInLeft {
-          to {
-            opacity: 1;
-            transform: translateX(0);
-          }
-        }
-      </style>
-        
-<h3 id="hacking-title"
-  style="
-    font-size: 30px;
-    font-weight: bold;
-    margin-top: -20px;
-    color: #ffc005;
-    letter-spacing: 2px;
-    font-family: 'Space Grotesk', 'Consolas', monospace;
-    min-height: 40px;
-  ">
-</h3>
-<script>
-  // Hacking typing animation for "Web Developer"
-  const text = "Computer Engineering Student";
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
-  const el = document.getElementById("hacking-title");
-  let display = "";
-  let i = 0;
-
-  function hackType() {
-    if (i <= text.length) {
-      // Show correct chars + random chars for the rest
-      let shown = text.slice(0, i);
-      let randoms = "";
-      for (let j = i; j < text.length; j++) {
-        randoms += chars[Math.floor(Math.random() * chars.length)];
-      }
-      el.textContent = shown + randoms;
-      i++;
-      setTimeout(hackType, 50);
-    } else {
-      el.textContent = text;
-    }
-  }
-  hackType();
-</script>
-
-<style>
-  .slide-up-invisible {
-    opacity: 0;
-    transform: translateY(100%);
-    animation: slideUpFade 1s cubic-bezier(.4,1.7,.6,1) 1s forwards;
-    /* 2.5s delay to start after the hacking animation */
-  }
-  @keyframes slideUpFade {
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-</style>
-
-<div class="slide-up-invisible" style="display: flex; align-items: center; gap: 24px;   text-shadow: 0px 2px 5px rgba(0, 0, 0);
-">
-  <p class="mt-2 text-gray-200" style="margin: 0;">@ FOE Ain Shams University</p>
-  <div style="display: flex; gap: 24px; font-size: 42px; align-items: center; margin: 0;">
-    <a href="https://github.com/TadrosKaram" target="_blank" class="social-icon" style="display: inline-flex; align-items: center;">
-      <i class="fab fa-github"></i>
-    </a>
-    <a href="https://www.linkedin.com/in/tadros-karam/" target="_blank" class="social-icon" style="display: inline-flex; align-items: center;">
-      <i class="fab fa-linkedin"></i>
-    </a>
-    <a href="Tadros_Karam_Resume_2.pdf" target="_blank" download="" style="display: inline-flex; align-items: center;">
-      <i class="fas fa-file" style="font-size: 22px; color: #D1D5DB; margin-right: 6px;" onmouseover="this.style.color='#ffc005';" onmouseout="this.style.color='#D1D5DB'"></i>
-      <span style="font-size: 15px; color: #D1D5DB;">Download Resume</span>
-    </a>
-  </div>
-  
-
-</div>
-<br><br>
-  <p class="scroll-hint" style="background: linear-gradient(90deg,rgb(241, 166, 52),#d4b21a); box-shadow: 20px 22px 70px rgba(0, 0, 0, 0.25); width: 250px; height: 50px; border-radius: 20px; text-align: center; border: 2px solid white; display: flex; align-items: center; justify-content: center; margin: 0 0 0 24px;">
-    ↓ Scroll for more
-  </p>
-</div>
-
-
-
-</div>
-
-
-
-
-
-
-
-    </div>
-    </div>
-    
-
-
+          <div class="slide-up-invisible inline-style-9">
+            <p class="mt-2 text-gray-200 inline-style-10">
+              @ FOE Ain Shams University
+            </p>
+            <div class="inline-style-11">
+              <a
+                href="https://github.com/TadrosKaram"
+                target="_blank"
+                class="social-icon inline-style-12"
+              >
+                <i class="fab fa-github"></i>
+              </a>
+              <a
+                href="https://www.linkedin.com/in/tadros-karam/"
+                target="_blank"
+                class="social-icon inline-style-13"
+              >
+                <i class="fab fa-linkedin"></i>
+              </a>
+              <a
+                href="Tadros_Karam_Resume_2.pdf"
+                target="_blank"
+                download=""
+                class="inline-style-14"
+              >
+                <i class="fas fa-file inline-style-15"></i>
+                <span class="inline-style-16">Download Resume</span>
+              </a>
+            </div>
+          </div>
+          <br /><br />
+          <p class="scroll-hint inline-style-17">↓ Scroll for more</p>
+        </div>
+      </div>
     </header>
 
+    <main class="inline-style-18">
+      <section id="about" class="inline-style-19">
+        <div class="text-center mb-12">
+          <h2
+            class="text-5xl font-bold text-[#ffc005] tracking-wide border-b-4 border-[#ffc005] inline-block pb-2"
+          >
+            <i>About Me</i>
+          </h2>
+        </div>
+        <div
+          class="max-w-5xl mx-auto px-8 text-gray-400 text-2xl leading-9 text-center inline-style-20"
+        >
+          <p>
+            I'm <span class="inline-style-21">Tadros Karam</span>, a Computer
+            Engineering student at Ain Shams University
+            <span class="inline-style-22">passionate and eager</span> to learn
+            more and I love what I do been on a computer since I was 6 years
+            old,
+            <span class="inline-style-23"
+              >My life has been revolving around it ever since.</span
+            >
+          </p>
 
-  
+          <hr class="inline-style-24" />
+          <p>
+            I’m currently exploring different fields in computer engineering,
+            including
+            <span class="inline-style-25">Web development </span> (need to
+            master it more and learn more frameworks) and
+            <span class="inline-style-26">Machine Learning</span> (soon) and
+            <span class="inline-style-27">CyberSecurity</span> (soon) by testing
+            out different fields and projects i will discover before i graduate
+            my passion and what field I will
+            <span class="inline-style-28">excel in</span>.
+          </p>
+        </div>
+      </section>
 
-     
+      <hr />
 
+      <section id="skills" class="py-20 text-white">
+        <!-- Title -->
+        <div class="text-center mb-12">
+          <h2
+            class="text-5xl font-bold text-[#ffc005] tracking-wide border-b-4 border-[#ffc005] inline-block pb-2"
+          >
+            <i>Skills</i>
+          </h2>
+        </div>
 
-    <main style="width: 80%; margin: auto; " >
+        <br /><br />
 
-      <section id="about" style="margin-top: 120px; height: 70vh;">
-  <div class="text-center mb-12">
-    <h2 class="text-5xl font-bold text-[#ffc005] tracking-wide border-b-4 border-[#ffc005] inline-block pb-2">
-      <i>About Me</i>
-    </h2>
-  </div>
-  <div class="max-w-5xl mx-auto px-8 text-gray-400 text-2xl leading-9 text-center" style="margin: 10vh auto; border: 2px solid #ffc005; border-radius: 10px; padding: 20px;  font-family:Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;">
-    <p >
-      I'm <span style="color: #ffc005; font-weight: bold;">Tadros Karam</span>, a Computer Engineering student at Ain Shams University <span style="color: #ffc005; font-weight: bold;">passionate and eager</span>  to learn more and I love what I do been on a computer since I was 6 years old, <span style="color: #ffc005; font-weight: bold;">My life has been revolving around it ever since.</span> 
-    </p>
-  
-    <hr style="
-      border: none;
-      height: 4px;
-      width: 400px;
-      margin: 36px auto 36px auto;
-      background: linear-gradient(90deg, #ffc005 0%, #fffacd 100%);
-      border-radius: 8px;
-      box-shadow: 0 2px 16px 0 rgba(255,192,5,0.18);
-      opacity: 0.85;
-    ">
-    <p >
-      I’m currently exploring different fields in computer engineering, including <span style="color: #ffc005; font-weight: bold;">Web development </span> (need to master it more and learn more frameworks) and <span style="color: #ffc005; font-weight: bold;">Machine Learning</span> (soon) and <span style="color: #ffc005; font-weight: bold;">CyberSecurity</span> (soon) by testing out different fields and projects i will discover before i graduate my passion and what field I will <span style="color: #ffc005; font-weight: bold;">excel in</span>.
-    </p>
-  </div>
-</section>
+        <!-- Grid -->
+        <div
+          class="max-w-7xl mx-auto px-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8 m-auto inline-style-29"
+        >
+          <!-- Skill Item -->
+          <div class="skill-card">
+            <img
+              src="https://cdn-icons-png.flaticon.com/512/732/732212.png"
+              alt="HTML"
+            />
+            <span>HTML</span>
+          </div>
 
-<hr>
+          <div class="skill-card">
+            <img
+              src="https://cdn-icons-png.flaticon.com/512/732/732190.png"
+              alt="CSS"
+            />
+            <span>CSS</span>
+          </div>
 
-<section id="skills" class="py-20 text-white ">
-  <!-- Title -->
-  <div class="text-center mb-12">
-    <h2 class="text-5xl font-bold text-[#ffc005] tracking-wide border-b-4 border-[#ffc005] inline-block pb-2">
-      <i>Skills</i>
-    </h2>
-  </div>
+          <div class="skill-card">
+            <img
+              src="https://www.vectorlogo.zone/logos/tailwindcss/tailwindcss-icon.svg"
+              alt="Tailwind CSS"
+            />
+            <span>Tailwind</span>
+          </div>
 
-  <br><br>
+          <div class="skill-card">
+            <img
+              src="https://cdn-icons-png.flaticon.com/512/5968/5968672.png"
+              alt="Bootstrap"
+            />
+            <span>Bootstrap</span>
+          </div>
 
-  <!-- Grid -->
-  <div class="max-w-7xl mx-auto px-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8 m-auto" style="margin:auto">
-    <!-- Skill Item -->
-    <div class="skill-card">
-      <img src="https://cdn-icons-png.flaticon.com/512/732/732212.png" alt="HTML">
-      <span>HTML</span>
-      
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://cdn-icons-png.flaticon.com/512/5968/5968292.png"
+              alt="JavaScript"
+            />
+            <span>JavaScript</span>
+          </div>
 
-    <div class="skill-card">
-      <img src="https://cdn-icons-png.flaticon.com/512/732/732190.png" alt="CSS">
-      <span>CSS</span>
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://cdn-icons-png.flaticon.com/512/5968/5968332.png"
+              alt="PHP"
+            />
+            <span>PHP</span>
+          </div>
 
-    <div class="skill-card">
-      <img src="https://www.vectorlogo.zone/logos/tailwindcss/tailwindcss-icon.svg" alt="Tailwind CSS">
-      <span>Tailwind</span>
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://cdn.worldvectorlogo.com/logos/laravel-2.svg"
+              alt="Laravel"
+            />
+            <span>Laravel</span>
+          </div>
 
-    <div class="skill-card">
-      <img src="https://cdn-icons-png.flaticon.com/512/5968/5968672.png" alt="Bootstrap">
-      <span>Bootstrap</span>
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://cdn-icons-png.flaticon.com/512/528/528260.png"
+              alt="MySQL"
+            />
+            <span>MySQL</span>
+          </div>
 
-    <div class="skill-card">
-      <img src="https://cdn-icons-png.flaticon.com/512/5968/5968292.png" alt="JavaScript">
-      <span>JavaScript</span>
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg"
+              alt="Java"
+            />
+            <span>Java</span>
+          </div>
 
-    <div class="skill-card">
-      <img src="https://cdn-icons-png.flaticon.com/512/5968/5968332.png" alt="PHP">
-      <span>PHP</span>
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-original.svg"
+              alt="C++"
+            />
+            <span>C++</span>
 
-    <div class="skill-card">
-      <img src="https://cdn.worldvectorlogo.com/logos/laravel-2.svg" alt="Laravel">
-      <span>Laravel</span>
-    </div>
-
-    <div class="skill-card">
-      <img src="https://cdn-icons-png.flaticon.com/512/528/528260.png" alt="MySQL">
-      <span>MySQL</span>
-    </div>
-
-    <div class="skill-card">
-      <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" alt="Java">
-      <span>Java</span>
-    </div>
-
-    <div class="skill-card">
-      <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-original.svg" alt="C++">
-      <span>C++</span>
-
-      <p class="text-gray-600 mt-2">Familiar</p>
-    </div>
-
-    <div class="skill-card">
-      <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python">
-      <span>Python</span>
             <p class="text-gray-600 mt-2">Familiar</p>
+          </div>
 
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg"
+              alt="Python"
+            />
+            <span>Python</span>
+            <p class="text-gray-600 mt-2">Familiar</p>
+          </div>
 
-    <div class="skill-card">
-      <img src="https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png" alt="Git">
-      <span>Git</span>
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png"
+              alt="Git"
+            />
+            <span>Git</span>
+          </div>
 
-    <div class="skill-card">
-      <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/matlab/matlab-original.svg" alt="MATLAB">
-      <span>MATLAB</span>
-      
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/matlab/matlab-original.svg"
+              alt="MATLAB"
+            />
+            <span>MATLAB</span>
+          </div>
 
-    <div class="skill-card">
-      <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linux/linux-original.svg" alt="Linux">
-      <span>Linux</span>
-    </div>
+          <div class="skill-card">
+            <img
+              src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linux/linux-original.svg"
+              alt="Linux"
+            />
+            <span>Linux</span>
+          </div>
 
-<div class="skill-card">
-  <img
-    src="https://www.podfeet.com/blog/wp-content/uploads/2021/09/GitHub-Copilot-logo-1040x650.png"
-    alt="GitHub Copilot Logo"
-    style="object-fit: contain; width: 50%; height: 50%;"
+          <div class="skill-card">
+            <img
+              src="https://www.podfeet.com/blog/wp-content/uploads/2021/09/GitHub-Copilot-logo-1040x650.png"
+              alt="GitHub Copilot Logo"
+              class="inline-style-30"
+            />
+            <span>GitHub Copilot</span>
+          </div>
 
-  >
-  <span>GitHub Copilot</span>
-</div>
+          <div class="skill-card">
+            <img
+              src="https://conserto.pro/wp-content/uploads/2022/11/microsoftteams-image-56.png"
+              alt="GitHub Copilot Logo"
+              class="inline-style-31"
+            />
+            <span>Codex </span>
+            <p class="text-gray-600 mt-2">OpenAI</p>
+          </div>
+        </div>
+        <br /><br />
+      </section>
 
-<div class="skill-card">
-  <img
-    src="https://conserto.pro/wp-content/uploads/2022/11/microsoftteams-image-56.png"
-    alt="GitHub Copilot Logo"
-    style="object-fit: contain; width: 50%; height: 50%;"
+      <hr />
 
-  >
-  <span>Codex </span>
-              <p class="text-gray-600 mt-2">OpenAI</p>
+      <section id="projects" class="mb-32 pt-20">
+        <!-- title -->
+        <div class="section-title-center mb-8 flex flex-col items-center">
+          <h2
+            class="text-6xl section-title text-center font-extrabold tracking-wide inline-style-32"
+          >
+            <i class="fa-solid fa-diagram-project mr-3 text-gray-400"></i>
+            <span class="inline-style-33">Projects</span>
+          </h2>
+          <br />
+          <br />
+          <p
+            class="mt-4 text-lg text-gray-300 max-w-2xl text-center inline-style-34"
+          >
+            Explore a selection of my featured projects, showcasing my skills in
+            web development, Java, PHP, and more. Click on any card to view
+            details or see a live demo!
+          </p>
+        </div>
+        <br /><br /><br /><br />
+        <!-- projects grid -->
+        <div
+          class="projects-grid grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-8 mt-12 px-2"
+        >
+          <!-- Card 1 -->
+          <a
+            href="fstask.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-35"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                PHP Register Form
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                A simple registration form that connects to a MySQL database
+                using PHP. Demonstrates backend integration and user data
+                handling.
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 2 -->
+          <a
+            href="phplogin.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-36"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                College System Authenticator
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                A college management system with login authentication,
+                role-based access, CRUD operations, and session handling. Built
+                with PHP and MySQL.
+              </p>
+              <br /><br />
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 3 -->
+          <a
+            href="https://javaprojectasu-cse231.netlify.app/"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-37"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Java Hotel Management System
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                Using java to create a full hotel system booking checkout room
+                types and a simple ui visit the project site for details
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Full Project Details Site
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 4 -->
+          <a
+            href="https://tadroskaram.github.io/number-guess.js/"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-38"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Guess The Number Game
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                A fun JavaScript game where users try to guess a randomly
+                generated number. Features interactive UI and instant feedback.
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              Test Project for yourself
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 5 -->
+          <a
+            href="https://tadroskaram.github.io/nti-clone-task1/"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-39"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Frontend Page Clone
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                A clone of a website front end
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Site Clone Live
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 6 -->
+          <a
+            href="TaskMySQL.png"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-40"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                MySQL Database Clone
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                A project demonstrating the process of cloning an entire MySQL
+                database, useful for backups and migrations.
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 7 -->
+          <a
+            href="carplate.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-41"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Car Plate System
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                A Java-based car plate management system with duplicate
+                avoidance, random plate generation, and special plate features.
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
 
+          <a
+            href="lyricjava.mp4"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-42"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Lyrics system
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                lyrics system just like in music apps using java
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
 
+          <!-- Card 9 -->
+          <a
+            href="gpacalc.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-43"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                GPA Calculator
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                gpa calculator with UI using JavaFX with the ability to
+                calculate CGPA and edit and many more view for yourself
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 10 -->
+          <a
+            href="javacalc.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-44"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Simple Calculator
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                Simple calculator with UI using JavaFX
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
 
+          <!-- Card 11 -->
+          <a
+            href="passwordjava.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-45"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Strong Password Generator
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                With the ability to choose how many symbols, numbers and letters
+                and position randomly across the generated password
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 12 -->
+          <a
+            href="Quizjava.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-46"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Quiz App
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                Built with UI using javaFX
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 13 -->
+          <a
+            href="wikisearch.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-47"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Local Wikipedia search
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                Local search of wikipedia websites with ui using JavaFX
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Project
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
 
-
-
-
-
-      
-    </div>
-  </div>
-  <br><br>
-</section>
-
-<hr>
-
-
-
-
-<section id="projects" class="mb-32 pt-20 ">
-  <!-- title -->
-  <div class="section-title-center mb-8 flex flex-col items-center">
-    <h2 class="text-6xl section-title text-center font-extrabold tracking-wide" style="color: #ffc005; letter-spacing: 2px; text-shadow: 0 4px 24px rgba(255,192,5,0.15);">
-      <i class="fa-solid fa-diagram-project mr-3 text-gray-400"></i>
-      <span style="font-family: 'Space Grotesk', 'Consolas', monospace; color: #ffc005;">Projects</span>
-    </h2>
-    <br>
-    <br>
-    <p class="mt-4 text-lg text-gray-300 max-w-2xl text-center" style="font-family: 'Inter', sans-serif; border: 2px solid #ffc005; border-radius: 8px; padding: 12px;">
-      Explore a selection of my featured projects, showcasing my skills in web development, Java, PHP, and more. Click on any card to view details or see a live demo!
-    </p>
-    
-  </div>
-  <br><br><br><br>
-  <!-- projects grid -->
-  <div class="projects-grid grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-8 mt-12 px-2">
-    <!-- Card 1 -->
-    <a href="fstask.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQdTYRK6tmMsMp58Xvlm1Z5KvLjP9zv50rNmg&s') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">PHP Register Form</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">A simple registration form that connects to a MySQL database using PHP. Demonstrates backend integration and user data handling.</p>
-
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-    <!-- Card 2 -->
-    <a href="phplogin.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTCMv4JAeDMdh5y1NUWlFb2X-lMtDcr5Tu5QA&s') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">College System Authenticator</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">A college management system with login authentication, role-based access, CRUD operations, and session handling. Built with PHP and MySQL.</p>
-        <br><br>
-     
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-    <!-- Card 3 -->
-    <a href="https://javaprojectasu-cse231.netlify.app/" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSUz-ljBUHgvIJYKlb3Z3mc_452JBJsAEEYuw&s') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Java Hotel Management System</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">Using java to create a full hotel system booking checkout room types and a simple ui visit the project site for details</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Full Project Details Site
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-    <!-- Card 4 -->
-    <a href="https://tadroskaram.github.io/number-guess.js/" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('guessthenumber.gif') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Guess The Number Game</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">A fun JavaScript game where users try to guess a randomly generated number. Features interactive UI and instant feedback.</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        Test Project for yourself
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-    <!-- Card 5 -->
-    <a href="https://tadroskaram.github.io/nti-clone-task1/" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('task1-nti.png') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Frontend Page Clone</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">A clone of a website front end</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Site Clone Live
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-    <!-- Card 6 -->
-    <a href="TaskMySQL.png" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('TaskMySQL.png') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">MySQL Database Clone</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">A project demonstrating the process of cloning an entire MySQL database, useful for backups and migrations.</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-    <!-- Card 7 -->
-    <a href="carplate.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ0-kQ0B_cD51fGMpfclihPUwz_CXo8FuJQwQ&s') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Car Plate System</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">A Java-based car plate management system with duplicate avoidance, random plate generation, and special plate features.</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-
-     <a href="lyricjava.mp4" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://www.butlerbranding.com/wp-content/uploads/2019/09/Spotify-Logo-Large.jpg') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Lyrics system</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">lyrics system just like in music apps using java</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-
-         <!-- Card 9 -->
-    <a href="gpacalc.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQcUL1vjhADgl6TyBLY0zkOHkJpSCkeLkVOg&s') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">GPA Calculator</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">gpa calculator with UI using JavaFX with the ability to calculate CGPA and edit and many more view for yourself</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-            <!-- Card 10 -->
-    <a href="javacalc.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTcuqZpxzUU47pk2cEyKSGy_S7CXBoAszF80A&s) center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Simple Calculator</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">Simple calculator with UI using JavaFX</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-
-            <!-- Card 11 -->
-    <a href="passwordjava.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://www.seoclerk.com/pics/002/124/985/fe0eb05f178eb242f2567c204f4854d7.jpg') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Strong Password Generator</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">With the ability to choose how many symbols, numbers and letters and position randomly across the generated password</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-            <!-- Card 12 -->
-    <a href="Quizjava.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ_4Xy_wNfcgC-OlJxa2r64hzNvwde4pYzxbRqpmWhywnBcAzNAmmQeF8T89lJUWZc6plA&usqp=CAU') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Quiz App</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">Built with UI using javaFX</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-            <!-- Card 13 -->
-    <a href="wikisearch.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTp4zgEfdz5GHeGYVqZ6MJFqK9wK91Fg6OBow&s') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Local Wikipedia search</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">Local search of wikipedia websites with ui using JavaFX</p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        View Project
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-
-                <!-- Card 14 -->
-    <a href="piggamejs.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('piggamejs.gif') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Pig Game</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">A pig game with JavaScript
-          <br>
-          Rules:
-          <br>
-          - Roll the dice to accumulate points. 
-          <br>
-          - Choose to hold and save points or risk losing them.
-          <br>
-          - If you roll a 1, you lose all points for that turn.
-          <br>
-          - First player to reach 100 points wins.
-        </p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-        Test Project for yourself
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-      <!-- Card 15 -->
-    <a href="todolistlaravel.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('todolistlaravel.gif') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Todo-List</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">Todolist using laravel, MySQL features: CRUD operation with a simple UI
-        </p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-       View Preview
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
+          <!-- Card 14 -->
+          <a
+            href="piggamejs.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-48"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Pig Game
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                A pig game with JavaScript
+                <br />
+                Rules:
+                <br />
+                - Roll the dice to accumulate points.
+                <br />
+                - Choose to hold and save points or risk losing them.
+                <br />
+                - If you roll a 1, you lose all points for that turn.
+                <br />
+                - First player to reach 100 points wins.
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              Test Project for yourself
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
+          <!-- Card 15 -->
+          <a
+            href="todolistlaravel.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-49"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Todo-List
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                Todolist using laravel, MySQL features: CRUD operation with a
+                simple UI
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Preview
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
 
           <!-- Card 16 -->
-    <a href="attendkashafa.gif" target="_blank" class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden" style="min-height: 260px; background: url('https://media.istockphoto.com/id/1198430065/vector/attendance-concept-vector-flat-design.jpg?s=612x612&w=0&k=20&c=Q21HKmopEQcN1mhGYNPzRYMWtjla-C-eyGyVEPpoJ5w=') center/cover no-repeat;">
-      <div class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"></div>
-      <div class="relative z-10">
-        <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">Attendance system</h3>
-        <p class="text-gray-100 mb-8 drop-shadow">A web application for managing attendance using Native PHP and MySQL.
-        </p>
-      </div>
-      <span class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10">
-       View Preview
-        <i class="fas fa-arrow-right"></i>
-      </span>
-    </a>
-  </div>
-</section>
-
-<hr>
-
-<section id="exp" class=" py-20 px-4" style="display: flex; justify-content: center; margin: 200px 0px;">
-  <div class="max-w-7xl mx-auto flex flex-col items-center justify-center">
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-14 w-full justify-items-center">
-      <!-- Experience card -->
-      <div class="w-full max-w-2xl bg-[#181d24] text-white rounded-3xl border-2 border-[#ffc005]/40 shadow-2xl p-12 flex flex-col justify-between hover:scale-[1.03] transition duration-300 experience-card-lg">
-        <div class="flex items-center gap-6 mb-8">
-          <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTjjE1so9vdok-71BKkeEdFJhO1ai33BDFN7w&s" class="w-20 h-20 rounded-lg object-contain bg-[#23272f] p-2 shadow-md" alt="NTI Logo">
-          <h2 class="text-4xl font-extrabold text-[#ffc005] tracking-wide">Experience</h2>
+          <a
+            href="attendkashafa.gif"
+            target="_blank"
+            class="group relative rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 border-2 border-[#ffc005] flex flex-col justify-between p-6 cursor-pointer hover:scale-105 overflow-hidden inline-style-50"
+          >
+            <div
+              class="absolute inset-0 bg-black/70 group-hover:bg-black/60 transition duration-300 z-0"
+            ></div>
+            <div class="relative z-10">
+              <h3 class="text-2xl font-bold text-[#ffc005] mb-2 drop-shadow-lg">
+                Attendance system
+              </h3>
+              <p class="text-gray-100 mb-8 drop-shadow">
+                A web application for managing attendance using Native PHP and
+                MySQL.
+              </p>
+            </div>
+            <span
+              class="absolute bottom-4 right-6 text-[#ffc005] font-semibold flex items-center gap-2 group-hover:underline z-10"
+            >
+              View Preview
+              <i class="fas fa-arrow-right"></i>
+            </span>
+          </a>
         </div>
-        <h3 class="text-2xl font-bold mb-4">NTI - Fullstack Training</h3>
-        <p class="text-gray-200 text-lg leading-relaxed mb-6">
-          Practiced <span class="text-[#ffc005] font-semibold">Front-end</span> (HTML, CSS, Bootstrap, JS),
-          <span class="text-[#ffc005] font-semibold">Back-end</span> (PHP, Laravel, MySQL).<br>
-          Also covered <span class="text-[#ffc005] font-semibold">Soft skills</span>, freelancing, and professional work.
-        </p>
-        <div class="flex justify-between items-center text-base text-gray-400 mt-6">
-          <span>June–July 2025</span>
-          <span class="bg-[#ffc005]/20 text-[#ffc005] px-4 py-2 rounded-full font-bold tracking-wide">Training</span>
+      </section>
+
+      <hr />
+
+      <section id="exp" class="py-20 px-4 inline-style-51">
+        <div
+          class="max-w-7xl mx-auto flex flex-col items-center justify-center"
+        >
+          <div
+            class="grid grid-cols-1 lg:grid-cols-2 gap-14 w-full justify-items-center"
+          >
+            <!-- Experience card -->
+            <div
+              class="w-full max-w-2xl bg-[#181d24] text-white rounded-3xl border-2 border-[#ffc005]/40 shadow-2xl p-12 flex flex-col justify-between hover:scale-[1.03] transition duration-300 experience-card-lg"
+            >
+              <div class="flex items-center gap-6 mb-8">
+                <img
+                  src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTjjE1so9vdok-71BKkeEdFJhO1ai33BDFN7w&amp;s"
+                  class="w-20 h-20 rounded-lg object-contain bg-[#23272f] p-2 shadow-md"
+                  alt="NTI Logo"
+                />
+                <h2
+                  class="text-4xl font-extrabold text-[#ffc005] tracking-wide"
+                >
+                  Experience
+                </h2>
+              </div>
+              <h3 class="text-2xl font-bold mb-4">NTI - Fullstack Training</h3>
+              <p class="text-gray-200 text-lg leading-relaxed mb-6">
+                Practiced
+                <span class="text-[#ffc005] font-semibold">Front-end</span>
+                (HTML, CSS, Bootstrap, JS),
+                <span class="text-[#ffc005] font-semibold">Back-end</span> (PHP,
+                Laravel, MySQL).<br />
+                Also covered
+                <span class="text-[#ffc005] font-semibold">Soft skills</span>,
+                freelancing, and professional work.
+              </p>
+              <div
+                class="flex justify-between items-center text-base text-gray-400 mt-6"
+              >
+                <span>June–July 2025</span>
+                <span
+                  class="bg-[#ffc005]/20 text-[#ffc005] px-4 py-2 rounded-full font-bold tracking-wide"
+                  >Training</span
+                >
+              </div>
+            </div>
+            <!-- Education card -->
+            <div
+              class="w-full max-w-2xl bg-[#0560A1] text-[#e5e7eb] rounded-3xl border-2 border-[#ffc005]/40 shadow-2xl p-12 flex flex-col justify-between hover:scale-[1.03] transition duration-300 education-card-lg inline-style-52"
+            >
+              <div class="flex items-center gap-6 mb-8">
+                <img
+                  src="engasu.jpg"
+                  class="w-20 h-20 rounded-lg object-contain p-2 shadow-md"
+                  alt="Ain Shams Logo"
+                />
+              </div>
+              <h3 class="text-2xl font-bold mb-4">
+                Computer Engineering Undergraduate<br />@ FOE Ain Shams
+                University
+              </h3>
+
+              <div
+                class="flex justify-between items-center text-base text-gray-400 mt-6"
+              >
+                <span>2021–Present</span>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <!-- Education card -->
-      <div class="w-full max-w-2xl bg-[#0560A1] text-[#e5e7eb] rounded-3xl border-2 border-[#ffc005]/40 shadow-2xl p-12 flex flex-col justify-between hover:scale-[1.03] transition duration-300 education-card-lg" style="display: flex; justify-content: center; flex-direction: column; align-items: center;">
-        <div class="flex items-center gap-6 mb-8">
-          <img src="engasu.jpg" class="w-20 h-20 rounded-lg object-contain  p-2 shadow-md" alt="Ain Shams Logo">
-          
+      </section>
+
+      <section id="certifications-section" class="py-20">
+        <div class="text-center mb-12">
+          <h2
+            class="text-5xl font-bold tracking-wide border-b-4 border-[#ffc005] inline-block pb-2 inline-style-53"
+          >
+            <i></i>Certifications
+          </h2>
         </div>
-        <h3 class="text-2xl font-bold mb-4">Computer Engineering Undergraduate<br>@ FOE Ain Shams University</h3>
-     
-        <div class="flex justify-between items-center text-base text-gray-400 mt-6">
-          <span>2021–Present</span>
+        <div
+          class="cert-container grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-10 justify-items-center px-4 inline-style-54"
+        >
+          <a href="cert1.png" target="_blank" class="cert-link group">
+            <div
+              class="cert-card rounded-2xl shadow-lg border-2 border-[#ffc005] overflow-hidden transition-transform duration-300 group-hover:scale-105 group-hover:shadow-2xl bg-gray-900 relative inline-style-55"
+            >
+              <div
+                class="cert-overlay absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center"
+              >
+                <span
+                  class="text-[#ffc005] text-xl font-bold bg-black/60 px-4 py-2 rounded-lg"
+                  >View Certificate</span
+                >
+              </div>
+            </div>
+          </a>
+          <a href="cer2.png" target="_blank" class="cert-link group">
+            <div
+              class="cert-card rounded-2xl shadow-lg border-2 border-[#ffc005] overflow-hidden transition-transform duration-300 group-hover:scale-105 group-hover:shadow-2xl bg-gray-900 relative inline-style-56"
+            >
+              <div
+                class="cert-overlay absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center"
+              >
+                <span
+                  class="text-[#ffc005] text-xl font-bold bg-black/60 px-4 py-2 rounded-lg"
+                  >View Certificate</span
+                >
+              </div>
+            </div>
+          </a>
+          <a href="cert3.png" target="_blank" class="cert-link group">
+            <div
+              class="cert-card rounded-2xl shadow-lg border-2 border-[#ffc005] overflow-hidden transition-transform duration-300 group-hover:scale-105 group-hover:shadow-2xl bg-gray-900 relative inline-style-57"
+            >
+              <div
+                class="cert-overlay absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center"
+              >
+                <span
+                  class="text-[#ffc005] text-xl font-bold bg-black/60 px-4 py-2 rounded-lg"
+                  >View Certificate</span
+                >
+              </div>
+            </div>
+          </a>
+          <a href="cert4.png" target="_blank" class="cert-link group">
+            <div
+              class="cert-card rounded-2xl shadow-lg border-2 border-[#ffc005] overflow-hidden transition-transform duration-300 group-hover:scale-105 group-hover:shadow-2xl bg-gray-900 relative inline-style-58"
+            >
+              <div
+                class="cert-overlay absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center"
+              >
+                <span
+                  class="text-[#ffc005] text-xl font-bold bg-black/60 px-4 py-2 rounded-lg"
+                  >View Certificate</span
+                >
+              </div>
+            </div>
+          </a>
         </div>
-      </div>
-    </div>
-  </div>
-  <style>
-    @media (max-width: 1024px) {
-      .experience-card-lg, .education-card-lg {
-        padding: 2rem !important;
-        max-width: 100% !important;
-      }
-      .experience-card-lg h2, .education-card-lg h2 {
-        font-size: 2.2rem !important;
-      }
-      .experience-card-lg h3, .education-card-lg h3 {
-        font-size: 1.3rem !important;
-      }
-    }
-    @media (max-width: 640px) {
-      .experience-card-lg, .education-card-lg {
-        padding: 1rem !important;
-        max-width: 100% !important;
-      }
-      .experience-card-lg h2, .education-card-lg h2 {
-        font-size: 1.3rem !important;
-      }
-      .experience-card-lg h3, .education-card-lg h3 {
-        font-size: 1rem !important;
-      }
-    }
-  </style>
-</section>
-
-<section id="certifications-section" class="py-20">
-  <div class="text-center mb-12">
-    <h2 class="text-5xl font-bold tracking-wide border-b-4 border-[#ffc005] inline-block pb-2 " style="margin-bottom: 0;">
-      <i></i>Certifications
-    </h2>
-  </div>
-  <div class="cert-container grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-10 justify-items-center px-4" style="margin: 60px 0;">
-    <a href="cert1.png" target="_blank" class="cert-link group">
-      <div class="cert-card rounded-2xl shadow-lg border-2 border-[#ffc005] overflow-hidden transition-transform duration-300 group-hover:scale-105 group-hover:shadow-2xl bg-gray-900 relative" style="aspect-ratio: 4/3; background: url(cert1.jpg) center/cover no-repeat;">
-        <div class="cert-overlay absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
-          <span class="text-[#ffc005] text-xl font-bold bg-black/60 px-4 py-2 rounded-lg">View Certificate</span>
-        </div>
-      </div>
-    </a>
-    <a href="cer2.png" target="_blank" class="cert-link group">
-      <div class="cert-card rounded-2xl shadow-lg border-2 border-[#ffc005] overflow-hidden transition-transform duration-300 group-hover:scale-105 group-hover:shadow-2xl bg-gray-900 relative" style="aspect-ratio: 4/3; background: url(cer2.png) center/cover no-repeat;">
-        <div class="cert-overlay absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
-          <span class="text-[#ffc005] text-xl font-bold bg-black/60 px-4 py-2 rounded-lg">View Certificate</span>
-        </div>
-      </div>
-    </a>
-    <a href="cert3.png" target="_blank" class="cert-link group">
-      <div class="cert-card rounded-2xl shadow-lg border-2 border-[#ffc005] overflow-hidden transition-transform duration-300 group-hover:scale-105 group-hover:shadow-2xl bg-gray-900 relative" style="aspect-ratio: 4/3; background: url(cert3.png) center/cover no-repeat;">
-        <div class="cert-overlay absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
-          <span class="text-[#ffc005] text-xl font-bold bg-black/60 px-4 py-2 rounded-lg">View Certificate</span>
-        </div>
-      </div>
-    </a>
-    <a href="cert4.png" target="_blank" class="cert-link group">
-      <div class="cert-card rounded-2xl shadow-lg border-2 border-[#ffc005] overflow-hidden transition-transform duration-300 group-hover:scale-105 group-hover:shadow-2xl bg-gray-900 relative" style="aspect-ratio: 4/3; background: url(cert4.png) center/cover no-repeat;">
-        <div class="cert-overlay absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
-          <span class="text-[#ffc005] text-xl font-bold bg-black/60 px-4 py-2 rounded-lg">View Certificate</span>
-        </div>
-      </div>
-    </a>
-  </div>
-  <style>
-    .cert-card {
-      min-width: 220px;
-      min-height: 160px;
-      cursor: pointer;
-      transition: box-shadow 0.3s, transform 0.3s;
-      box-shadow: 0 4px 24px rgba(255,192,5,0.10), 0 1.5px 8px rgba(0,0,0,0.10);
-      background-color: #23272f;
-    }
-    .cert-card:hover {
-      box-shadow: 0 8px 32px rgba(255,192,5,0.18), 0 4px 16px rgba(0,0,0,0.18);
-      transform: scale(1.04);
-    }
-    .cert-overlay {
-      pointer-events: none;
-    }
-    @media (max-width: 1024px) {
-      .cert-container {
-        grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-      }
-    }
-    @media (max-width: 640px) {
-      .cert-container {
-        grid-template-columns: 1fr !important;
-      }
-      .cert-card {
-        min-width: 100px;
-        min-height: 80px;
-      }
-    }
-  </style>
-</section>
-
-        
-
-
-
-
-      
-
-        
-
+      </section>
     </main>
 
-<footer style="width: 100%; height: 70px; background-color: #152938; color: #D1D5DB; display: flex; align-items: center; justify-content: center; font-size: 30px; font-style: italic;">Thanks for visiting! , email: tadroskaram20@gmail.com</footer>
+    <footer class="inline-style-59">
+      Thanks for visiting! , email: tadroskaram20@gmail.com
+    </footer>
 
+    <a
+      href="#home"
+      id="scrollToTopBtn"
+      title="Back to top"
+      class="inline-style-60"
+    >
+      ⬆
+    </a>
 
-<script>
-// Lazy load fade-in for each section in <main>
-document.addEventListener('DOMContentLoaded', function() {
-  const main = document.querySelector('main');
-  if (!main) return;
-  const sections = Array.from(main.children).filter(el => el.tagName === 'SECTION' || el.classList.contains('section-border'));
-  sections.forEach(section => {
-    section.classList.add('lazy-fade');
-  });
-  const observer = new IntersectionObserver((entries, obs) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('fade-in-visible');
-        obs.unobserve(entry.target);
-      }
-    });
-  }, { threshold: 0.15 });
-  sections.forEach(section => observer.observe(section));
-});
-</script>
-<style>
-.lazy-fade {
-  opacity: 0;
-  
-  transition: opacity 2.5s cubic-bezier(.4,1.7,.6,1), transform 0.8s cubic-bezier(.4,1.7,.6,1);
-}
-.fade-in-visible {
-  opacity: 1 !important;
-  transform: none !important;
-}
-main {
-  width: 80% !important;
-  margin-left: auto !important;
-  margin-right: auto !important;
-}
-@media (max-width: 1024px) {
-  main {
-    width: 95% !important;
-  }
-}
-@media (max-width: 640px) {
-  main {
-    width: 100% !important;
-  }
-}
-</style>
-
-  
-
-<a href="#home" id="scrollToTopBtn" title="Back to top" style="
-  opacity: 0;
-  pointer-events: none;
-  position: fixed;
-  right: 20px;
-  bottom: 20px;
-  font-size: 60px;
-  z-index: 999;
-  background: #ffc005;
-  color: #152938;
-  border: none;
-  border-radius: 50%;
-  width: 70px;
-  height: 70px;
-  box-shadow: 0 4px 16px rgba(255,192,5,0.18);
-  text-align: center;
-  line-height: 70px;
-  cursor: pointer;
-  transition: opacity 0.7s cubic-bezier(.4,1.7,.6,1), transform 0.7s cubic-bezier(.4,1.7,.6,1);
-  text-decoration: none;
-  transform: translateY(40px);
-">
-  ⬆
-</a>
-<script>
-  // Improved scroll-to-top button logic for smooth entrance and no random disappearing
-  document.addEventListener('DOMContentLoaded', function() {
-    const scrollBtn = document.getElementById('scrollToTopBtn');
-    const headerSection = document.querySelector('header');
-    function checkScroll() {
-      const headerBottom = headerSection.getBoundingClientRect().bottom + window.scrollY;
-      if (window.scrollY > headerBottom - 30) {
-        scrollBtn.style.opacity = '1';
-        scrollBtn.style.pointerEvents = 'auto';
-        scrollBtn.style.transform = 'translateY(0)';
-      } else {
-        scrollBtn.style.opacity = '0';
-        scrollBtn.style.pointerEvents = 'none';
-        scrollBtn.style.transform = 'translateY(40px)';
-      }
-    }
-    window.addEventListener('scroll', checkScroll, { passive: true });
-    checkScroll();
-  });
-</script>
-<style>
-.scroll-slide-up {
-  opacity: 0;
-  transform: translateY(40px);
-  transition: opacity 2s cubic-bezier(.4,1.7,.6,1), transform 2s cubic-bezier(.4,1.7,.6,1);
-}
-.scroll-slide-up.visible {
-  opacity: 1 !important;
-  transform: translateY(0) !important;
-}
-</style>
-  
-
-
-<script>
-// Highlight nav link for section in view (improved logic)
-document.addEventListener('DOMContentLoaded', function() {
-
-  // Map 'home' to header section instead of document.body
-  const headerSection = document.querySelector('header');
-  const sections = sectionIds.map(id => id === 'home' ? headerSection : document.getElementById(id)).filter(Boolean);
-  function onScroll() {
-    let current = null;
-    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-    let maxVisible = 0;
-    let maxIndex = 0;
-    for (let i = 0; i < sections.length; i++) {
-      const section = sections[i];
-      if (section) {
-        const rect = section.getBoundingClientRect();
-        const visible = Math.max(0, Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0));
-        if (visible > maxVisible) {
-          maxVisible = visible;
-          maxIndex = i;
-        }
-      }
-    }
-    current = sectionIds[maxIndex];
-    navLinks.forEach(link => {
-      if (link.getAttribute('href') === '#' + current) {
-        link.classList.add('active-section-link');
-      } else {
-        link.classList.remove('active-section-link');
-      }
-    });
-  }
-  window.addEventListener('scroll', onScroll, { passive: true });
-  onScroll();
-});
-
-document.addEventListener('DOMContentLoaded', function () {
-  const themeBtn = document.getElementById('theme-toggle');
-  const header = document.querySelector('header');
-
-  // Load saved theme or default to light
-  const savedTheme = localStorage.getItem('theme') || 'light';
-  applyTheme(savedTheme);
-
-  themeBtn.addEventListener('click', function () {
-    const isLight = document.body.classList.contains('light-theme');
-    const newTheme = isLight ? 'dark' : 'light';
-    applyTheme(newTheme);
-    localStorage.setItem('theme', newTheme);
-  });
-
-  function applyTheme(theme) {
-    const isLight = theme === 'light';
-
-    document.body.classList.toggle('light-theme', isLight);
-
-    if (isLight) {
-      document.body.style.background = '';
-      document.body.style.color = '';
-    
-     
-
-        themeBtn.innerHTML = '<i class="fas fa-moon"></i> Dark Mode';
-      themeBtn.style.backgroundColor = 'black';
-      themeBtn.style.color = 'white';
-          if (header) {
-      header.style.background = 'linear-gradient(120deg, #f3f4f6 60%, #e5e7eb 100%)';
-    }
-
-    } else {
-      document.body.style.background = '#161515';
-      document.body.style.color = '#f8fafc';
-       themeBtn.innerHTML = '<i class="fas fa-sun"></i> Light Mode';
-      themeBtn.style.backgroundColor = 'orange';
-      themeBtn.style.color = 'black';
-            if (header) {
-          header.style.background = 'linear-gradient(120deg, #181d24 60%, #23272f 100%)';
-
-    }
-    
-    }
-  }
-});
-
-</script>
-<style>
-.active-section-link {
-  color: #ffc005 !important;
-  font-weight: bold;
-  background: rgba(255,192,5,0.08);
-  border-radius: 6px;
-  transition: all 0.2s;
-}
-</style>
-
-<script src="script.js"></script>
-
-
-</body>
-
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -9,3 +9,212 @@ hamburgerBtn.addEventListener("click", () => {
 });
 
 //////////////////////////////////////
+
+// Global navigation helpers
+const sectionIds = [
+  "home",
+  "about",
+  "skills",
+  "projects",
+  "exp",
+  "certifications-section",
+];
+const navLinks = Array.from(document.querySelectorAll("nav a"));
+
+// extracted from index.html
+// Hamburger menu toggle for small screens, always show nav on large screens
+document.addEventListener("DOMContentLoaded", function () {
+  const btn = document.getElementById("nav-hamburger");
+  const navList = document.getElementById("main-nav-list");
+  function updateNavDisplay() {
+    if (window.innerWidth > 1024) {
+      navList.classList.add("open");
+      navList.style.display = "flex";
+    } else {
+      navList.classList.remove("open");
+      navList.style.display = "";
+    }
+  }
+  updateNavDisplay();
+  window.addEventListener("resize", updateNavDisplay);
+
+  if (!btn || !navList) return;
+  btn.addEventListener("click", function () {
+    if (window.innerWidth <= 1024) {
+      navList.classList.toggle("open");
+      if (navList.classList.contains("open")) {
+        navList.style.display = "flex";
+      } else {
+        navList.style.display = "";
+      }
+    }
+  });
+  // Close menu when clicking a link (on small screens)
+  navList.querySelectorAll("a").forEach((link) => {
+    link.addEventListener("click", function () {
+      if (window.innerWidth <= 1024) {
+        navList.classList.remove("open");
+        navList.style.display = "";
+      }
+    });
+  });
+});
+
+// extracted from index.html
+// Hacking typing animation for "Web Developer"
+const text = "Computer Engineering Student";
+const chars =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+const el = document.getElementById("hacking-title");
+let display = "";
+let i = 0;
+
+function hackType() {
+  if (i <= text.length) {
+    // Show correct chars + random chars for the rest
+    let shown = text.slice(0, i);
+    let randoms = "";
+    for (let j = i; j < text.length; j++) {
+      randoms += chars[Math.floor(Math.random() * chars.length)];
+    }
+    el.textContent = shown + randoms;
+    i++;
+    setTimeout(hackType, 50);
+  } else {
+    el.textContent = text;
+  }
+}
+hackType();
+
+// extracted from index.html
+// Lazy load fade-in for each section in <main>
+document.addEventListener("DOMContentLoaded", function () {
+  const main = document.querySelector("main");
+  if (!main) return;
+  const sections = Array.from(main.children).filter(
+    (el) => el.tagName === "SECTION" || el.classList.contains("section-border"),
+  );
+  sections.forEach((section) => {
+    section.classList.add("lazy-fade");
+  });
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("fade-in-visible");
+          obs.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.15 },
+  );
+  sections.forEach((section) => observer.observe(section));
+});
+
+// extracted from index.html
+// Improved scroll-to-top button logic for smooth entrance and no random disappearing
+document.addEventListener("DOMContentLoaded", function () {
+  const scrollBtn = document.getElementById("scrollToTopBtn");
+  const headerSection = document.querySelector("header");
+  function checkScroll() {
+    const headerBottom =
+      headerSection.getBoundingClientRect().bottom + window.scrollY;
+    if (window.scrollY > headerBottom - 30) {
+      scrollBtn.style.opacity = "1";
+      scrollBtn.style.pointerEvents = "auto";
+      scrollBtn.style.transform = "translateY(0)";
+    } else {
+      scrollBtn.style.opacity = "0";
+      scrollBtn.style.pointerEvents = "none";
+      scrollBtn.style.transform = "translateY(40px)";
+    }
+  }
+  window.addEventListener("scroll", checkScroll, { passive: true });
+  checkScroll();
+});
+
+// extracted from index.html
+// Highlight nav link for section in view (improved logic)
+document.addEventListener("DOMContentLoaded", function () {
+  // Map 'home' to header section instead of document.body
+  const headerSection = document.querySelector("header");
+  const sections = sectionIds
+    .map((id) => (id === "home" ? headerSection : document.getElementById(id)))
+    .filter(Boolean);
+  function onScroll() {
+    let current = null;
+    const viewportHeight =
+      window.innerHeight || document.documentElement.clientHeight;
+    let maxVisible = 0;
+    let maxIndex = 0;
+    for (let i = 0; i < sections.length; i++) {
+      const section = sections[i];
+      if (section) {
+        const rect = section.getBoundingClientRect();
+        const visible = Math.max(
+          0,
+          Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0),
+        );
+        if (visible > maxVisible) {
+          maxVisible = visible;
+          maxIndex = i;
+        }
+      }
+    }
+    current = sectionIds[maxIndex];
+    navLinks.forEach((link) => {
+      if (link.getAttribute("href") === "#" + current) {
+        link.classList.add("active-section-link");
+      } else {
+        link.classList.remove("active-section-link");
+      }
+    });
+  }
+  window.addEventListener("scroll", onScroll, { passive: true });
+  onScroll();
+});
+
+document.addEventListener("DOMContentLoaded", function () {
+  const themeBtn = document.getElementById("theme-toggle");
+  const header = document.querySelector("header");
+
+  // Load saved theme or default to light
+  const savedTheme = localStorage.getItem("theme") || "light";
+  applyTheme(savedTheme);
+
+  themeBtn.addEventListener("click", function () {
+    const isLight = document.body.classList.contains("light-theme");
+    const newTheme = isLight ? "dark" : "light";
+    applyTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
+  });
+
+  function applyTheme(theme) {
+    const isLight = theme === "light";
+
+    document.body.classList.toggle("light-theme", isLight);
+
+    if (isLight) {
+      document.body.style.background = "";
+      document.body.style.color = "";
+
+      themeBtn.innerHTML = '<i class="fas fa-moon"></i> Dark Mode';
+      themeBtn.style.backgroundColor = "black";
+      themeBtn.style.color = "white";
+      if (header) {
+        header.style.background =
+          "linear-gradient(120deg, #f3f4f6 60%, #e5e7eb 100%)";
+      }
+    } else {
+      document.body.style.background = "#161515";
+      document.body.style.color = "#f8fafc";
+      themeBtn.innerHTML = '<i class="fas fa-sun"></i> Light Mode';
+      themeBtn.style.backgroundColor = "orange";
+      themeBtn.style.color = "black";
+      if (header) {
+        header.style.background =
+          "linear-gradient(120deg, #181d24 60%, #23272f 100%)";
+      }
+    }
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1170,3 +1170,403 @@ nav ul li a:hover::after {
 .hide-scroll {
   display: none;
 }
+
+/* extracted from index.html */
+.glow-rotate-wrapper {
+     position: relative;
+     width: 580px;
+     height: 580px;
+     display: flex;
+     align-items: center;
+     justify-content: center;
+      
+  border-radius: 50%;
+      }
+ .glow-rotate {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(
+    #fffacd 0deg,      /* LemonChiffon */
+    #ffc107 60deg,     /* Amber */
+    #f59e0b 120deg,    /* Golden Orange */
+    #facc15 180deg,    /* Sunflower */
+    #ffeb3b 240deg,    /* Bright Yellow */
+    #ffd700 300deg,    /* Gold */
+    #fffacd 360deg     /* Back to LemonChiffon */
+  );
+  filter: blur(40px) brightness(1.1);
+  z-index: 999;
+  animation: rotateGlow 5s linear infinite;
+  opacity: 0.25;
+}
+
+ 
+  
+      @keyframes rotateGlow {
+     100% {
+       transform: rotate(360deg);
+     }
+      }
+
+/* extracted from index.html */
+/* Hamburger visible only on small screens */
+      @media (max-width: 1024px) {
+        #nav-hamburger {
+          display: block !important;
+        }
+        #main-nav-list {
+          display: none;
+          position: absolute;
+          top: 70px;
+          left: 0;
+          width: 100vw;
+          flex-direction: column;
+          background: rgba(35, 37, 37, 0.97);
+          gap: 0;
+          padding: 20px 0 10px 0;
+          z-index: 1100;
+        }
+        #main-nav-list.open {
+          display: flex !important;
+        }
+        #main-nav-list li {
+          margin: 0 0 18px 0;
+          text-align: center;
+        }
+        #main-nav-list li:last-child {
+          margin-bottom: 0;
+        }
+      }
+      @media (min-width: 1025px) {
+        #main-nav-list {
+          display: flex !important;
+          position: static;
+          flex-direction: row;
+          background: none;
+          gap: 30px;
+        }
+        #nav-hamburger {
+          display: none !important;
+        }
+      }
+
+/* extracted from index.html */
+.slide-in-left {
+          opacity: 0;
+          transform: translateX(-100%);
+          animation: slideInLeft 1s cubic-bezier(.4,1.7,.6,1) forwards;
+        }
+        @keyframes slideInLeft {
+          to {
+            opacity: 1;
+            transform: translateX(0);
+          }
+        }
+
+/* extracted from index.html */
+.slide-up-invisible {
+    opacity: 0;
+    transform: translateY(100%);
+    animation: slideUpFade 1s cubic-bezier(.4,1.7,.6,1) 1s forwards;
+    /* 2.5s delay to start after the hacking animation */
+  }
+  @keyframes slideUpFade {
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+/* extracted from index.html */
+@media (max-width: 1024px) {
+      .experience-card-lg, .education-card-lg {
+        padding: 2rem !important;
+        max-width: 100% !important;
+      }
+      .experience-card-lg h2, .education-card-lg h2 {
+        font-size: 2.2rem !important;
+      }
+      .experience-card-lg h3, .education-card-lg h3 {
+        font-size: 1.3rem !important;
+      }
+    }
+    @media (max-width: 640px) {
+      .experience-card-lg, .education-card-lg {
+        padding: 1rem !important;
+        max-width: 100% !important;
+      }
+      .experience-card-lg h2, .education-card-lg h2 {
+        font-size: 1.3rem !important;
+      }
+      .experience-card-lg h3, .education-card-lg h3 {
+        font-size: 1rem !important;
+      }
+    }
+
+/* extracted from index.html */
+.cert-card {
+      min-width: 220px;
+      min-height: 160px;
+      cursor: pointer;
+      transition: box-shadow 0.3s, transform 0.3s;
+      box-shadow: 0 4px 24px rgba(255,192,5,0.10), 0 1.5px 8px rgba(0,0,0,0.10);
+      background-color: #23272f;
+    }
+    .cert-card:hover {
+      box-shadow: 0 8px 32px rgba(255,192,5,0.18), 0 4px 16px rgba(0,0,0,0.18);
+      transform: scale(1.04);
+    }
+    .cert-overlay {
+      pointer-events: none;
+    }
+    @media (max-width: 1024px) {
+      .cert-container {
+        grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+      }
+    }
+    @media (max-width: 640px) {
+      .cert-container {
+        grid-template-columns: 1fr !important;
+      }
+      .cert-card {
+        min-width: 100px;
+        min-height: 80px;
+      }
+    }
+
+/* extracted from index.html */
+.lazy-fade {
+  opacity: 0;
+  
+  transition: opacity 2.5s cubic-bezier(.4,1.7,.6,1), transform 0.8s cubic-bezier(.4,1.7,.6,1);
+}
+.fade-in-visible {
+  opacity: 1 !important;
+  transform: none !important;
+}
+main {
+  width: 80% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+@media (max-width: 1024px) {
+  main {
+    width: 95% !important;
+  }
+}
+@media (max-width: 640px) {
+  main {
+    width: 100% !important;
+  }
+}
+
+/* extracted from index.html */
+.scroll-slide-up {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 2s cubic-bezier(.4,1.7,.6,1), transform 2s cubic-bezier(.4,1.7,.6,1);
+}
+.scroll-slide-up.visible {
+  opacity: 1 !important;
+  transform: translateY(0) !important;
+}
+
+/* extracted from index.html */
+.active-section-link {
+  color: #ffc005 !important;
+  font-weight: bold;
+  background: rgba(255,192,5,0.08);
+  border-radius: 6px;
+  transition: all 0.2s;
+}
+
+.inline-style-1 { width: 100%; border-bottom: 4px solid #ffc005;  }
+
+.inline-style-2 { margin-right: -200px; width: 50%; display: flex; align-items: center; justify-content: center; }
+
+.inline-style-3 { 
+       width: 550px;
+       height: 550px;
+       background-image: url('Screenshot_7-removebg-preview\ \(1\).png');
+       background-size: cover;
+       background-repeat: no-repeat;
+       background-position:initial;
+       border-bottom-right-radius: 20px;
+       border-radius: 50%;
+       z-index: 2;
+       position: relative;
+      }
+
+.inline-style-4 { 
+    position: fixed;
+  top: 15px;
+  right: 20px;
+    background-color: #161515;
+    color: white;
+    padding: 10px 16px;
+    border: none;
+    border-radius: 8px;
+    font-weight: bold;
+    cursor: pointer;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    transition: background-color 0.3s ease; }
+
+.inline-style-5 { width: 50%; }
+
+.inline-style-6 { display: flex; align-items: center; justify-content: center; flex-direction: column; height: 100%; }
+
+.inline-style-7 { font-size: 100px; background-color: white; -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+
+.inline-style-8 { 
+    font-size: 30px;
+    font-weight: bold;
+    margin-top: -20px;
+    color: #ffc005;
+    letter-spacing: 2px;
+    font-family: 'Space Grotesk', 'Consolas', monospace;
+    min-height: 40px;
+   }
+
+.inline-style-9 { display: flex; align-items: center; gap: 24px;   text-shadow: 0px 2px 5px rgba(0, 0, 0);
+ }
+
+.inline-style-10 { margin: 0; }
+
+.inline-style-11 { display: flex; gap: 24px; font-size: 42px; align-items: center; margin: 0; }
+
+.inline-style-12 { display: inline-flex; align-items: center; }
+
+.inline-style-13 { display: inline-flex; align-items: center; }
+
+.inline-style-14 { display: inline-flex; align-items: center; }
+
+.inline-style-15 { font-size: 22px; color: #D1D5DB; margin-right: 6px; }
+.inline-style-15:hover { color: #ffc005; }
+
+.inline-style-16 { font-size: 15px; color: #D1D5DB; }
+
+.inline-style-17 { background: linear-gradient(90deg,rgb(241, 166, 52),#d4b21a); box-shadow: 20px 22px 70px rgba(0, 0, 0, 0.25); width: 250px; height: 50px; border-radius: 20px; text-align: center; border: 2px solid white; display: flex; align-items: center; justify-content: center; margin: 0 0 0 24px; }
+
+.inline-style-18 { width: 80%; margin: auto;  }
+
+.inline-style-19 { margin-top: 120px; height: 70vh; }
+
+.inline-style-20 { margin: 10vh auto; border: 2px solid #ffc005; border-radius: 10px; padding: 20px;  font-family:Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif; }
+
+.inline-style-21 { color: #ffc005; font-weight: bold; }
+
+.inline-style-22 { color: #ffc005; font-weight: bold; }
+
+.inline-style-23 { color: #ffc005; font-weight: bold; }
+
+.inline-style-24 { 
+      border: none;
+      height: 4px;
+      width: 400px;
+      margin: 36px auto 36px auto;
+      background: linear-gradient(90deg, #ffc005 0%, #fffacd 100%);
+      border-radius: 8px;
+      box-shadow: 0 2px 16px 0 rgba(255,192,5,0.18);
+      opacity: 0.85;
+     }
+
+.inline-style-25 { color: #ffc005; font-weight: bold; }
+
+.inline-style-26 { color: #ffc005; font-weight: bold; }
+
+.inline-style-27 { color: #ffc005; font-weight: bold; }
+
+.inline-style-28 { color: #ffc005; font-weight: bold; }
+
+.inline-style-29 { margin:auto }
+
+.inline-style-30 { object-fit: contain; width: 50%; height: 50%; }
+
+.inline-style-31 { object-fit: contain; width: 50%; height: 50%; }
+
+.inline-style-32 { color: #ffc005; letter-spacing: 2px; text-shadow: 0 4px 24px rgba(255,192,5,0.15); }
+
+.inline-style-33 { font-family: 'Space Grotesk', 'Consolas', monospace; color: #ffc005; }
+
+.inline-style-34 { font-family: 'Inter', sans-serif; border: 2px solid #ffc005; border-radius: 8px; padding: 12px; }
+
+.inline-style-35 { min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQdTYRK6tmMsMp58Xvlm1Z5KvLjP9zv50rNmg&s') center/cover no-repeat; }
+
+.inline-style-36 { min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTCMv4JAeDMdh5y1NUWlFb2X-lMtDcr5Tu5QA&s') center/cover no-repeat; }
+
+.inline-style-37 { min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSUz-ljBUHgvIJYKlb3Z3mc_452JBJsAEEYuw&s') center/cover no-repeat; }
+
+.inline-style-38 { min-height: 260px; background: url('guessthenumber.gif') center/cover no-repeat; }
+
+.inline-style-39 { min-height: 260px; background: url('task1-nti.png') center/cover no-repeat; }
+
+.inline-style-40 { min-height: 260px; background: url('TaskMySQL.png') center/cover no-repeat; }
+
+.inline-style-41 { min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ0-kQ0B_cD51fGMpfclihPUwz_CXo8FuJQwQ&s') center/cover no-repeat; }
+
+.inline-style-42 { min-height: 260px; background: url('https://www.butlerbranding.com/wp-content/uploads/2019/09/Spotify-Logo-Large.jpg') center/cover no-repeat; }
+
+.inline-style-43 { min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQcUL1vjhADgl6TyBLY0zkOHkJpSCkeLkVOg&s') center/cover no-repeat; }
+
+.inline-style-44 { min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTcuqZpxzUU47pk2cEyKSGy_S7CXBoAszF80A&s) center/cover no-repeat; }
+
+.inline-style-45 { min-height: 260px; background: url('https://www.seoclerk.com/pics/002/124/985/fe0eb05f178eb242f2567c204f4854d7.jpg') center/cover no-repeat; }
+
+.inline-style-46 { min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ_4Xy_wNfcgC-OlJxa2r64hzNvwde4pYzxbRqpmWhywnBcAzNAmmQeF8T89lJUWZc6plA&usqp=CAU') center/cover no-repeat; }
+
+.inline-style-47 { min-height: 260px; background: url('https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTp4zgEfdz5GHeGYVqZ6MJFqK9wK91Fg6OBow&s') center/cover no-repeat; }
+
+.inline-style-48 { min-height: 260px; background: url('piggamejs.gif') center/cover no-repeat; }
+
+.inline-style-49 { min-height: 260px; background: url('todolistlaravel.gif') center/cover no-repeat; }
+
+.inline-style-50 { min-height: 260px; background: url('https://media.istockphoto.com/id/1198430065/vector/attendance-concept-vector-flat-design.jpg?s=612x612&w=0&k=20&c=Q21HKmopEQcN1mhGYNPzRYMWtjla-C-eyGyVEPpoJ5w=') center/cover no-repeat; }
+
+.inline-style-51 { display: flex; justify-content: center; margin: 200px 0px; }
+
+.inline-style-52 { display: flex; justify-content: center; flex-direction: column; align-items: center; }
+
+.inline-style-53 { margin-bottom: 0; }
+
+.inline-style-54 { margin: 60px 0; }
+
+.inline-style-55 { aspect-ratio: 4/3; background: url(cert1.jpg) center/cover no-repeat; }
+
+.inline-style-56 { aspect-ratio: 4/3; background: url(cer2.png) center/cover no-repeat; }
+
+.inline-style-57 { aspect-ratio: 4/3; background: url(cert3.png) center/cover no-repeat; }
+
+.inline-style-58 { aspect-ratio: 4/3; background: url(cert4.png) center/cover no-repeat; }
+
+.inline-style-59 { width: 100%; height: 70px; background-color: #152938; color: #D1D5DB; display: flex; align-items: center; justify-content: center; font-size: 30px; font-style: italic; }
+
+.inline-style-60 { 
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  font-size: 60px;
+  z-index: 999;
+  background: #ffc005;
+  color: #152938;
+  border: none;
+  border-radius: 50%;
+  width: 70px;
+  height: 70px;
+  box-shadow: 0 4px 16px rgba(255,192,5,0.18);
+  text-align: center;
+  line-height: 70px;
+  cursor: pointer;
+  transition: opacity 0.7s cubic-bezier(.4,1.7,.6,1), transform 0.7s cubic-bezier(.4,1.7,.6,1);
+  text-decoration: none;
+  transform: translateY(40px);
+ }


### PR DESCRIPTION
## Summary
- move inline style blocks to `styles.css` and consolidate page styling with generated utility classes
- collect all inline scripts into `script.js` and add navigation helpers
- remove inline event handlers in favor of CSS hover state

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68909e8d7bb48333b7066409e072dae3